### PR TITLE
Demultiplex v2 - bclconvert with UMI

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -213,7 +213,7 @@ workflow PREPROCESS {
     
     main:
     fastq_to_ubam_umi(std_fq_input_ch)
-    markAdapters(fastq_to_ubam.out[0])
+    markAdapters(fastq_to_ubam_umi.out[0])
     align(markAdapters.out)
     markDup_cram(align.out)
     emit:

--- a/main.nf
+++ b/main.nf
@@ -218,9 +218,6 @@ workflow DEMULTIPLEX {
     }
     emit: 
     dna_fastq=bclConvert_DNA.out.dna_fastq
-    if (params.RNA) {
-        rna_fastq=bclConvert_RNA.out.rna_fastq
-    }
 }
 
 workflow PREPROCESS {

--- a/main.nf
+++ b/main.nf
@@ -155,20 +155,6 @@ def helpMessage() {
 }
 if (params.help) exit 0, helpMessage()
 
-/* TEST: BELOW ONLY IN MODULES FILE:
-if (params.localStorage) {
-aln_output_dir="${params.outdir}/"
-fastq_dir="${params.outdir}/"
-}
-if (!params.localStorage) {
-aln_output_dir="${tank_storage}/alignedData/${params.genome}/novaRuns/"
-fastq_dir="${tank_storage}/fastq_storage/novaRuns/"
-}
-*/
-
-//libParamLastLine-1="/data/shared/programmer/configfiles/library_param_last_line.v2.1.txt"
-//libParamLastLine-2="/data/shared/programmer/configfiles/library_param_last_line.v2.2.txt"
-
 
 channel
     .fromPath(params.runfolder)
@@ -180,37 +166,16 @@ channel
     .map { it -> it.simpleName}
     .set {runfolder_simplename } 
 
-if (!params.useBasesMask && !params.RNA) {
-  dnaMask="Y*,I8nnnnnnnnn,I8,Y*"
-}
-if (!params.useBasesMask && params.RNA) {
-  dnaMask="Y*,I8nnnnnnnnnnn,I8nn,Y*"
-  rnaMask="Y*,I10nnnnnnnnn,I10,Y*"
-}
-
-if (params.useBasesMask) {
-  dnaMask=params.useBasesMask
-  params.DNA=true
-}
-
-/*
-if (params.RNA) {
-    umiConvertDNA="Y151;I8N2U9;I8N2;Y151"
-    umiConvertRNA="Y151;I10U9;I10;Y151"
-}
-
-if (!params.RNA) {
-    umiConvertDNA="Y151;I8U9;I8;Y151"
-
-}
-*/
-
 
 
 log.info """\
-=======================================
-KGA Vejle demultiplex and Preprocess v1
-=======================================
+===============================================
+Clinical Genetics Vejle: Demultiplexing v2
+Last updated: feb. 2025
+Parameter information 
+===============================================
+Genome       : $params.genome
+Genome FASTA : $genome_fasta
 """
 
 channel
@@ -238,10 +203,6 @@ include {
          } from "./modules/demulti_modules.nf" 
 
 
-//from "${modules_dir}/demulti_modules.nf" 
-
-
-
 workflow DEMULTIPLEX {
     take:
     original_samplesheet
@@ -249,7 +210,6 @@ workflow DEMULTIPLEX {
     main:
     if (params.DNA) {
         prepare_DNA_samplesheet(original_samplesheet)
-        //bcl2fastq_DNA(runfolder_ch, prepare_DNA_samplesheet.out, xml_ch)
         bclConvert_DNA(runfolder_ch, prepare_DNA_samplesheet.out.umi, xml_ch)
     }
     if (params.RNA) {

--- a/main.nf
+++ b/main.nf
@@ -266,7 +266,7 @@ workflow {
 
         readsInputReMerged.view()
 
-    PREPROCESS(readsInputReMerged)
+    //PREPROCESS(readsInputReMerged)
     }
 }
 /*

--- a/main.nf
+++ b/main.nf
@@ -171,7 +171,7 @@ channel.fromPath(params.samplesheet)
 include {      
          // Preprocess tools:
          prepare_DNA_samplesheet;
-         bcl2fastq_DNA;
+         bclConvert_DNA;
          prepare_RNA_samplesheet; 
          bcl2fastq_RNA;
          fastq_to_ubam;

--- a/main.nf
+++ b/main.nf
@@ -8,7 +8,7 @@ date=new Date().format( 'yyMMdd' )
 params.rundir                   ="${launchDir.baseName}"            // get basename of dir where script is started
 params.outdir                   ='Results'                          // Default output folder.
 params.genome                   ="hg38"                             // Default assembly
-params.server                   ='lnx01'                            // Default server
+params.server                   =null                            // Default server
 
 // Unset parameters: 
 params.help                     =false

--- a/main.nf
+++ b/main.nf
@@ -30,6 +30,61 @@ params.keepwork 	            	=null
 runID="${date}.${user}.demultiV1"
 runtype="demultiAndPreprocessV1"
 
+switch (params.genome) {
+    case 'hg19':
+        assembly="hg19"
+        // Genome assembly files:
+        genome_fasta = "/data/shared/genomes/hg19/human_g1k_v37.fasta"
+        genome_fasta_fai = "/data/shared/genomes/hg19/human_g1k_v37.fasta.fai"
+        genome_fasta_dict = "/data/shared/genomes/hg19/human_g1k_v37.dict"
+        genome_version="V1"
+        break;
+
+
+    case 'hg38':
+        assembly="hg38"
+        // Genome assembly files:
+        if (params.hg38v1) {
+        genome_fasta = "/data/shared/genomes/hg38/GRCh38.primary.fa"
+        genome_fasta_fai = "/data/shared/genomes/hg38/GRCh38.primary.fa.fai"
+        genome_fasta_dict = "/data/shared/genomes/hg38/GRCh38.primary.dict"
+        genome_version="V1"
+        cnvkit_germline_reference_PON="/data/shared/genomes/hg38/inhouse_DBs/hg38v1_primary/cnvkit/wgs_germline_PON/jgmr_45samples.reference.cnn"
+        cnvkit_inhouse_cnn_dir="/data/shared/genomes/hg38/inhouse_DBs/hg38v1_primary/cnvkit/wgs_persample_cnn/"
+        inhouse_SV="/data/shared/genomes/hg38/inhouse_DBs/hg38v1_primary/"
+        }
+        
+        if (params.hg38v2){
+        genome_fasta = "/data/shared/genomes/hg38/ucsc.hg38.NGS.analysisSet.fa"
+        genome_fasta_fai = "/data/shared/genomes/hg38/ucsc.hg38.NGS.analysisSet.fa.fai"
+        genome_fasta_dict = "/data/shared/genomes/hg38/ucsc.hg38.NGS.analysisSet.dict"
+        genome_version="V2"
+        }
+        // Current hg38 version (v3): NGC with masks and decoys.
+        if (!params.hg38v2 && !params.hg38v1){
+        genome_fasta = "/data/shared/genomes/hg38/GRCh38_masked_v2_decoy_exclude.fa"
+        genome_fasta_fai = "/data/shared/genomes/hg38/GRCh38_masked_v2_decoy_exclude.fa.fai"
+        genome_fasta_dict = "/data/shared/genomes/hg38/GRCh38_masked_v2_decoy_exclude.dict"
+        genome_version="V3"
+        cnvkit_germline_reference_PON="/data/shared/genomes/hg38/inhouse_DBs/hg38v3_primary/cnvkit/hg38v3_109samples.cnvkit.reference.cnn"
+        cnvkit_inhouse_cnn_dir="/data/shared/genomes/hg38/inhouse_DBs/hg38v3_primary/cnvkit/wgs_persample_cnn/"
+        inhouse_SV="/data/shared//genomes/hg38/inhouse_DBs/hg38v3_primary/"
+        }
+
+
+        AV1_ROI="/data/shared/genomes/${params.genome}/interval.files/panels/av1.hg38.ROI.v2.bed"
+        CV1_ROI="/data/shared/genomes/${params.genome}/interval.files/panels/cv3.hg38.ROI.bed"
+        CV2_ROI="/data/shared/genomes/${params.genome}/interval.files/panels/cv3.hg38.ROI.bed"
+        CV3_ROI="/data/shared/genomes/${params.genome}/interval.files/panels/cv3.hg38.ROI.bed"
+        CV4_ROI="/data/shared/genomes/${params.genome}/interval.files/panels/cv4.hg38.ROI.bed"
+        CV5_ROI="/data/shared/genomes/${params.genome}/interval.files/panels/cv5.hg38.ROI.bed"
+        GV3_ROI="/data/shared/genomes/${params.genome}/interval.files/panels/gv3.hg38.ROI.v2.bed"
+        NV1_ROI="/data/shared/genomes/${params.genome}/interval.files/panels/nv1.hg38.ROI.bed"
+        WES_ROI="/data/shared/genomes/hg38/interval.files/exome.ROIs/211130.hg38.refseq.gencode.fullexons.50bp.SM.bed"
+        MV1_ROI="/data/shared/genomes/${params.genome}/interval.files/panels/muc1.hg38.coordinates.bed"
+ 
+        break;
+}
 
 def helpMessage() {
     log.info"""

--- a/main.nf
+++ b/main.nf
@@ -173,6 +173,7 @@ include {
          // Preprocess tools:
          prepare_DNA_samplesheet;
          bclConvert_DNA;
+         fastq_to_ubam_umi;
          prepare_RNA_samplesheet; 
          bclConvert_RNA;
          fastq_to_ubam;

--- a/main.nf
+++ b/main.nf
@@ -174,7 +174,7 @@ include {
          prepare_DNA_samplesheet;
          bclConvert_DNA;
          prepare_RNA_samplesheet; 
-         bcl2fastq_RNA;
+         bclConvert_RNA;
          fastq_to_ubam;
          markAdapters;
          align;
@@ -198,10 +198,11 @@ workflow DEMULTIPLEX {
     }
     if (params.RNA) {
         prepare_RNA_samplesheet(original_samplesheet)
-        bcl2fastq_RNA(runfolder_ch, prepare_RNA_samplesheet.out, xml_ch)
+        bclConvert_RNA(runfolder_ch, prepare_RNA_samplesheet.out.umi, xml_ch)
     }
     emit: 
     dna_fastq=bclConvert_DNA.out.dna_fastq
+    rna_fastq=bclConvert_RNA.out.rna_fastq
 }
 
 workflow PREPROCESS {
@@ -238,6 +239,7 @@ workflow {
         .combine(runfolder_simplename)
         .set { read_pairs_ch }
 
+
         read_pairs_ch
         .filter {it =~/AV1/||it =~/MV1/}
         .set { av1_channel }
@@ -248,7 +250,7 @@ workflow {
 
         av1_channel.concat(rest_channel)
         .set { std_fq_input_ch }
-
+        std_fq_input_ch.view()
     PREPROCESS(std_fq_input_ch)
     }
 }

--- a/main.nf
+++ b/main.nf
@@ -138,6 +138,19 @@ if (params.useBasesMask) {
   params.DNA=true
 }
 
+if (params.RNA) {
+    umiConvertDNA="Y151;I8N2U9;I8N2;Y151"
+    umiConvertRNA="Y151;I10U9;I10;Y151"
+}
+
+if (!params.RNA) {
+    umiConvertDNA="Y151;I8U9;I8;Y151"
+
+}
+
+
+
+
 log.info """\
 =======================================
 KGA Vejle demultiplex and Preprocess v1
@@ -179,14 +192,15 @@ workflow DEMULTIPLEX {
     main:
     if (params.DNA) {
         prepare_DNA_samplesheet(original_samplesheet)
-        bcl2fastq_DNA(runfolder_ch, prepare_DNA_samplesheet.out, xml_ch)
+        //bcl2fastq_DNA(runfolder_ch, prepare_DNA_samplesheet.out, xml_ch)
+        bclConvert_DNA(runfolder_ch, prepare_DNA_samplesheet.out.umi, xml_ch)
     }
     if (params.RNA) {
         prepare_RNA_samplesheet(original_samplesheet)
         bcl2fastq_RNA(runfolder_ch, prepare_RNA_samplesheet.out, xml_ch)
     }
     emit: 
-    dna_fastq=bcl2fastq_DNA.out.dna_fastq
+    dna_fastq=bclConvert_DNA.out.dna_fastq
 }
 
 workflow PREPROCESS {
@@ -239,6 +253,8 @@ workflow {
 }
 
 
+
+/*
 workflow.onComplete {
 
     // Extract the first six digits from the samplesheet name
@@ -275,3 +291,4 @@ workflow.onComplete {
     }
 }
 
+*/

--- a/main.nf
+++ b/main.nf
@@ -239,8 +239,6 @@ workflow {
 
     DEMULTIPLEX(original_samplesheet, xml_ch)
 
-    DEMULTIPLEX.out.dna_fastq.view()
-
     if (params.DNA && !params.skipAlign){
 
         DEMULTIPLEX.out.dna_fastq.flatten()
@@ -279,8 +277,6 @@ workflow {
         
         readsInputBranched.undetermined.concat(readsInputBranched.MV1).concat(readsInputBranched.EV8).concat(readsInputBranched.WGS)
         | set {readsInputReMerged}
-
-        readsInputReMerged.view()
 
     PREPROCESS(readsInputReMerged)
     fastq_to_ubam_umi(readsInputBranched.AV1PL)

--- a/main.nf
+++ b/main.nf
@@ -224,17 +224,6 @@ workflow {
     DEMULTIPLEX(original_samplesheet, xml_ch)
 
     DEMULTIPLEX.out.dna_fastq.view()
-        | map { id, reads -> 
-        (sample, ngstype)   = reads[0].baseName.tokenize("-")
-        (panel,subpanel)    = ngstype.tokenize("_")
-        meta = [id:sample+"_"+ngstype, npn:sample, fullpanel:ngstype,panel:panel, subpanel:subpanel]
-        [meta, reads]
-    }   
-        | set { reads_meta_ch}
-    
-reads_meta_ch.view()
-
-    Channel.fromFilePairs(DEMULTIPLEX.out.dna_fastq, checkIfExists: true)
 
     if (params.DNA && !params.skipAlign){
 

--- a/main.nf
+++ b/main.nf
@@ -265,7 +265,7 @@ workflow {
         | set {readsInputBranched}
         
         readsInputBranched.undetermined.concat(readsInputBranched.MV1).concat(readsInputBranched.WES).concat(readsInputBranched.WGS)
-        | set {readsInputReMerged}  // Re-merge the data for the undetermined, MV1, WES, and WGS samples - i.e. only leave out plasma (CTDNA) samples.
+        | set {readsInputReMerged}  // Re-merge the data for the undetermined (i.e. AV1), MV1, WES, and WGS samples - i.e. only leave out plasma (CTDNA) samples.
 
     PREPROCESS(readsInputReMerged)  // standard preprocessing for all but CTDNA
     //fastq_to_ubam_umi(readsInputBranched.CTDNA) // preprocessing for CTDNA

--- a/main.nf
+++ b/main.nf
@@ -218,7 +218,9 @@ workflow DEMULTIPLEX {
     }
     emit: 
     dna_fastq=bclConvert_DNA.out.dna_fastq
-    rna_fastq=bclConvert_RNA.out.rna_fastq
+    if (params.RNA) {
+        rna_fastq=bclConvert_RNA.out.rna_fastq
+    }
 }
 
 workflow PREPROCESS {

--- a/main.nf
+++ b/main.nf
@@ -176,7 +176,6 @@ include {
          fastq_to_ubam_umi;
          prepare_RNA_samplesheet; 
          bclConvert_RNA;
-         fastq_to_ubam;
          markAdapters;
          align;
          markDup_cram;

--- a/main.nf
+++ b/main.nf
@@ -48,7 +48,7 @@ switch (params.genome) {
         genome_fasta = "/data/shared/genomes/hg38/GRCh38.primary.fa"
         genome_fasta_fai = "/data/shared/genomes/hg38/GRCh38.primary.fa.fai"
         genome_fasta_dict = "/data/shared/genomes/hg38/GRCh38.primary.dict"
-        genome_version="V1"
+        genome_version="hg38v1"
         cnvkit_germline_reference_PON="/data/shared/genomes/hg38/inhouse_DBs/hg38v1_primary/cnvkit/wgs_germline_PON/jgmr_45samples.reference.cnn"
         cnvkit_inhouse_cnn_dir="/data/shared/genomes/hg38/inhouse_DBs/hg38v1_primary/cnvkit/wgs_persample_cnn/"
         inhouse_SV="/data/shared/genomes/hg38/inhouse_DBs/hg38v1_primary/"
@@ -58,14 +58,14 @@ switch (params.genome) {
         genome_fasta = "/data/shared/genomes/hg38/ucsc.hg38.NGS.analysisSet.fa"
         genome_fasta_fai = "/data/shared/genomes/hg38/ucsc.hg38.NGS.analysisSet.fa.fai"
         genome_fasta_dict = "/data/shared/genomes/hg38/ucsc.hg38.NGS.analysisSet.dict"
-        genome_version="V2"
+        genome_version="hg38v2"
         }
         // Current hg38 version (v3): NGC with masks and decoys.
         if (!params.hg38v2 && !params.hg38v1){
         genome_fasta = "/data/shared/genomes/hg38/GRCh38_masked_v2_decoy_exclude.fa"
         genome_fasta_fai = "/data/shared/genomes/hg38/GRCh38_masked_v2_decoy_exclude.fa.fai"
         genome_fasta_dict = "/data/shared/genomes/hg38/GRCh38_masked_v2_decoy_exclude.dict"
-        genome_version="V3"
+        genome_version="hg38v3"
         cnvkit_germline_reference_PON="/data/shared/genomes/hg38/inhouse_DBs/hg38v3_primary/cnvkit/hg38v3_109samples.cnvkit.reference.cnn"
         cnvkit_inhouse_cnn_dir="/data/shared/genomes/hg38/inhouse_DBs/hg38v3_primary/cnvkit/wgs_persample_cnn/"
         inhouse_SV="/data/shared//genomes/hg38/inhouse_DBs/hg38v3_primary/"
@@ -229,6 +229,7 @@ include {
          prepare_DNA_samplesheet;
          bclConvert_DNA;
          fastq_to_ubam_umi;
+         fastq_to_ubam;
          prepare_RNA_samplesheet; 
          bclConvert_RNA;
          markAdapters;
@@ -263,11 +264,11 @@ workflow DEMULTIPLEX {
 workflow PREPROCESS {
 
     take:
-    std_fq_input_ch
+    readsInputReMerged
     
     main:
-    fastq_to_ubam_umi(std_fq_input_ch)
-    markAdapters(fastq_to_ubam_umi.out[0])
+    fastq_to_ubam(readsInputReMerged)
+    markAdapters(fastq_to_ubam.out.ubam)
     align(markAdapters.out)
     markDup_cram(align.out)
     emit:
@@ -321,9 +322,11 @@ workflow {
 
         readsInputReMerged.view()
 
-    //PREPROCESS(readsInputReMerged)
+    PREPROCESS(readsInputReMerged)
+    fastq_to_ubam_umi(readsInputBranched.AV1PL)
     }
 }
+
 /*
 workflow {
 

--- a/main.nf
+++ b/main.nf
@@ -138,6 +138,7 @@ if (params.useBasesMask) {
   params.DNA=true
 }
 
+/*
 if (params.RNA) {
     umiConvertDNA="Y151;I8N2U9;I8N2;Y151"
     umiConvertRNA="Y151;I10U9;I10;Y151"
@@ -147,7 +148,7 @@ if (!params.RNA) {
     umiConvertDNA="Y151;I8U9;I8;Y151"
 
 }
-
+*/
 
 
 

--- a/modules/demulti_modules.nf
+++ b/modules/demulti_modules.nf
@@ -232,7 +232,7 @@ process prepare_RNA_samplesheet {
 process bcl2fastq_RNA {
     tag "$runfolder_simplename"
     errorStrategy 'ignore'
-    publishDir "${fastq_dir}/${runfolder_simplename}_umi/", mode: 'copy'
+    publishDir "${fastq_dir}/${runfolder_simplename}_UMI/", mode: 'copy'
 
     input:
     tuple val(runfolder_simplename), path(runfolder)// from runfolder_ch3

--- a/modules/demulti_modules.nf
+++ b/modules/demulti_modules.nf
@@ -206,16 +206,13 @@ process bclConvert_DNA {
     --sample-sheet ${dnaSS} \
     --bcl-input-directory ${runfolder} \
     --output-directory ${runfolder_simplename}_umi/
-    rm -rf Undetermined*
     
     singularity run -B ${s_bind} ${simgpath}/multiqc.sif \
     -c ${multiqc_config} \
-    -f -q . \
+    -f -q ${runfolder_simplename}_umi/ \
     -n ${runfolder_simplename}.DemultiplexRunStats.Multiqc.DNA.html
 
-    rm -rf Undetermined*
-
-
+    rm -rf ${runfolder_simplename}_umi/Undetermined*
     """
 }
 
@@ -261,14 +258,13 @@ process bclConvert_RNA {
     --sample-sheet ${rnaSS} \
     --bcl-input-directory ${runfolder} \
     --output-directory ${runfolder_simplename}_umi/
-    rm -rf Undetermined*
     
     singularity run -B ${s_bind} ${simgpath}/multiqc.sif \
     -c ${multiqc_config} \
-    -f -q . \
+    -f -q ${runfolder_simplename}_umi/ \
     -n ${runfolder_simplename}.DemultiplexRunStats.Multiqc.RNA.html
 
-    rm -rf Undetermined*
+    rm -rf ${runfolder_simplename}_umi/Undetermined*
     """
 }
 

--- a/modules/demulti_modules.nf
+++ b/modules/demulti_modules.nf
@@ -148,19 +148,6 @@ fastq_dir="${dataStorage}/fastqStorage/novaRuns/"
 qc_dir="${dataStorage}/fastqStorage/demultiQC/"
 }
 
-
-log.info """\
-===============================================
-Clinical Genetics Vejle: Demultiplexing v2
-Last updated: feb. 2025
-Parameter information 
-===============================================
-Genome       : $params.genome
-Genome FASTA : $genome_fasta
-"""
-
-
-
 /////////////////////////////////////////////////////////////////////////////
 ////////////////////////// DEMULTI PROCESSES: ///////////////////////////////
 /////////////////////////////////////////////////////////////////////////////
@@ -200,22 +187,6 @@ process prepare_RNA_samplesheet {
     sed 's/Settings]/&\\nOverrideCycles,${umiConvertRNA}\\nNoLaneSplitting,true\\nTrimUMI,0\\nCreateFastqIndexForReads,1/' ${samplesheet_basename}.RNA_SAMPLES.csv > ${samplesheet_basename}.RNA_SAMPLES.UMI.csv
     """
 }
-/*
-process prepare_DNA_samplesheet {
-
-    input:
-    tuple val(samplesheet_basename), path(samplesheet)// from original_samplesheet1
-
-    output:
-    path("*.DNA_SAMPLES.csv"), emit: std
-    path("*.UMI.csv"), emit: umi
-    shell:
-    '''
-    cat !{samplesheet} | grep -v "RV1" > !{samplesheet_basename}.DNA_SAMPLES.csv
-    sed 's/Settings]/&\nOverrideCycles,!{umiConvertDNA}\nNoLaneSplitting,true\nTrimUMI,0\nCreateFastqIndexForReads,1/' !{samplesheet_basename}.DNA_SAMPLES.csv > !{samplesheet_basename}.DNA_SAMPLES.UMI.csv
-    '''
-}
-*/
 
 process bclConvert_DNA {
     tag "$runfolder_simplename"
@@ -279,34 +250,6 @@ process bclConvert_RNA {
     """
 }
 
-/*
-process bcl2fastq_RNA {
-    tag "$runfolder_simplename"
-    errorStrategy 'ignore'
-    publishDir "${fastq_dir}/${runfolder_simplename}_UMI/", mode: 'copy'
-
-    input:
-    tuple val(runfolder_simplename), path(runfolder)// from runfolder_ch3
-    path(rnaSS)// from rnaSS1
-    path(runinfo)// from xml_ch2
-
-    output:
-    path("RNA_fastq/*.fastq.gz"), emit: rna_fastq// into (rna_fq_out,rna_fq_out2)
-
-    script:
-    """
-    bcl2fastq \
-    --sample-sheet ${rnaSS} \
-    --runfolder-dir ${runfolder} \
-    --use-bases-mask ${rnaMask} \
-    --no-lane-splitting \
-    -o RNA_fastq
-
-    rm -rf RNA_fastq/Undetermined*
-    """
-}
-*/
-
 ///////////////////////////////// PREPROCESS MODULES //////////////////////// 
 
 
@@ -323,7 +266,6 @@ process fastq_to_ubam {
 
     output:
     tuple val(meta), path("${meta.id}.unmapped.from.fq.bam"),emit:ubam// into (ubam_out1, ubam_out2)
-    tuple path(r1),path(r2)
     
     script:
     """
@@ -422,8 +364,6 @@ process markDup_cram {
     samtools index ${meta.id}.${genome_version}.cram
     """
 }
-
-
 
 
 // UMI based analysis

--- a/modules/demulti_modules.nf
+++ b/modules/demulti_modules.nf
@@ -158,7 +158,7 @@ process prepare_DNA_samplesheet {
     """
     cat ${samplesheet} | grep -v "RV1" > ${samplesheet_basename}.DNA_SAMPLES.csv
 
-    sed 's/Settings]/&\nOverrideCycles,${umiConvertDNA}\nNoLaneSplitting,true\nTrimUMI,0\nCreateFastqIndexForReads,1/' ${samplesheet_basename}.DNA_SAMPLES.csv > !{samplesheet_basename}.DNA_SAMPLES.UMI.csv
+    sed 's/Settings]/&\nOverrideCycles,${umiConvertDNA}\nNoLaneSplitting,true\nTrimUMI,0\nCreateFastqIndexForReads,1/' ${samplesheet_basename}.DNA_SAMPLES.csv > ${samplesheet_basename}.DNA_SAMPLES.UMI.csv
     """
 }
 /*

--- a/modules/demulti_modules.nf
+++ b/modules/demulti_modules.nf
@@ -235,7 +235,7 @@ process prepare_RNA_samplesheet {
     sed -n '1,/Sample_ID/p' ${samplesheet} > ${samplesheet_basename}.HEADER.txt
     cat ${samplesheet_basename}.HEADER.txt ${samplesheet_basename}.RNAsamples.intermediate.txt > ${samplesheet_basename}.RNA_SAMPLES.csv 
 
-    sed 's/Settings]/&\\nOverrideCycles,${umiConvertDNA}\\nNoLaneSplitting,true\\nTrimUMI,0\\nCreateFastqIndexForReads,1/' ${samplesheet_basename}.RNA_SAMPLES.csv > ${samplesheet_basename}.RNA_SAMPLES.UMI.csv
+    sed 's/Settings]/&\\nOverrideCycles,${umiConvertRNA}\\nNoLaneSplitting,true\\nTrimUMI,0\\nCreateFastqIndexForReads,1/' ${samplesheet_basename}.RNA_SAMPLES.csv > ${samplesheet_basename}.RNA_SAMPLES.UMI.csv
     """
 }
 

--- a/modules/demulti_modules.nf
+++ b/modules/demulti_modules.nf
@@ -191,18 +191,19 @@ process bclConvert_DNA {
     path(runinfo) // from xml_ch
 
     output:
-    path("*.fastq.gz"), emit: dna_fastq// into (dna_fq_out,dna_fq_out2)
+    path("${runfolder_simplename}_umi/*.fastq.gz"), emit: dna_fastq// into (dna_fq_out,dna_fq_out2)
     path("${runfolder_simplename}.DemultiplexRunStats.Multiqc.DNA.html")
     script:
     """
     bcl-convert \
     --sample-sheet ${dnaSS} \
     --bcl-input-directory ${runfolder} \
-    -o .
-
+    --output-directory ${runfolder_simplename}_umi/
+    rm -rf Undetermined*
+    
     singularity run -B ${s_bind} ${simgpath}/multiqc.sif \
     -c ${multiqc_config} \
-    -f -q  ${launchDir}/*/QC/DNA/ \
+    -f -q . \
     -n ${runfolder_simplename}.DemultiplexRunStats.Multiqc.DNA.html
 
     rm -rf Undetermined*

--- a/modules/demulti_modules.nf
+++ b/modules/demulti_modules.nf
@@ -193,7 +193,7 @@ process bclConvert_DNA {
     errorStrategy 'ignore'
 
     publishDir "${fastq_dir}/${runfolder_simplename}_umi", mode: 'copy', pattern:"*.fastq.gz"
-    publishDir "${qc_dir}/${runfolder_simplename}_umi/", mode: 'copy', pattern:"*.DNA.html"
+    publishDir "${qc_dir}/", mode: 'copy', pattern:"*.DNA.html"
 
     input:
     tuple val(runfolder_simplename), path(runfolder)// from runfolder_ch2
@@ -225,7 +225,7 @@ process bclConvert_RNA {
     errorStrategy 'ignore'
 
     publishDir "${fastq_dir}/${runfolder_simplename}_umi/", mode: 'copy', pattern:"*.fastq.gz"
-    publishDir "${qc_dir}/${runfolder_simplename}_umi/", mode: 'copy', pattern:"*.RNA.html"
+    publishDir "${qc_dir}/", mode: 'copy', pattern:"*.RNA.html"
 
     input:
     tuple val(runfolder_simplename), path(runfolder)// from runfolder_ch2

--- a/modules/demulti_modules.nf
+++ b/modules/demulti_modules.nf
@@ -85,6 +85,19 @@ switch (params.genome) {
         cnvkit_inhouse_cnn_dir="/data/shared/genomes/hg38/inhouse_DBs/hg38v3_primary/cnvkit/wgs_persample_cnn/"
         inhouse_SV="/data/shared//genomes/hg38/inhouse_DBs/hg38v3_primary/"
         }
+
+
+        AV1_ROI="/data/shared/genomes/${params.genome}/interval.files/panels/av1.hg38.ROI.v2.bed"
+        CV1_ROI="/data/shared/genomes/${params.genome}/interval.files/panels/cv3.hg38.ROI.bed"
+        CV2_ROI="/data/shared/genomes/${params.genome}/interval.files/panels/cv3.hg38.ROI.bed"
+        CV3_ROI="/data/shared/genomes/${params.genome}/interval.files/panels/cv3.hg38.ROI.bed"
+        CV4_ROI="/data/shared/genomes/${params.genome}/interval.files/panels/cv4.hg38.ROI.bed"
+        CV5_ROI="/data/shared/genomes/${params.genome}/interval.files/panels/cv5.hg38.ROI.bed"
+        GV3_ROI="/data/shared/genomes/${params.genome}/interval.files/panels/gv3.hg38.ROI.v2.bed"
+        NV1_ROI="/data/shared/genomes/${params.genome}/interval.files/panels/nv1.hg38.ROI.bed"
+        WES_ROI="/data/shared/genomes/hg38/interval.files/exome.ROIs/211130.hg38.refseq.gencode.fullexons.50bp.SM.bed"
+        MV1_ROI="/data/shared/genomes/${params.genome}/interval.files/panels/muc1.hg38.coordinates.bed"
+ 
         break;
 }
 

--- a/modules/demulti_modules.nf
+++ b/modules/demulti_modules.nf
@@ -192,8 +192,8 @@ process bclConvert_DNA {
     tag "$runfolder_simplename"
     errorStrategy 'ignore'
 
-    publishDir "${fastq_dir}/", mode: 'copy', pattern:"${runfolder_simplename}_umi/*.fastq.gz"
-    publishDir "${qc_dir}/${runfolder_simplename}_UMI/", mode: 'copy', pattern:"*.DNA.html"
+    publishDir "${fastq_dir}/${runfolder_simplename}_umi", mode: 'copy', pattern:"*.fastq.gz"
+    publishDir "${qc_dir}/${runfolder_simplename}_umi/", mode: 'copy', pattern:"*.DNA.html"
 
     input:
     tuple val(runfolder_simplename), path(runfolder)// from runfolder_ch2
@@ -201,8 +201,8 @@ process bclConvert_DNA {
     path(runinfo) // from xml_ch
 
     output:
-    path("${runfolder_simplename}_umi/*.fastq.gz"), emit: dna_fastq// into (dna_fq_out,dna_fq_out2)
-    path("${runfolder_simplename}.DemultiplexRunStats.Multiqc.DNA.html")
+    path("*.fastq.gz"), emit: dna_fastq// into (dna_fq_out,dna_fq_out2)
+    path("*.Multiqc.DNA.html")
     script:
     """
     bcl-convert \
@@ -214,8 +214,9 @@ process bclConvert_DNA {
     -c ${multiqc_config} \
     -f -q ${runfolder_simplename}_umi/ \
     -n ${runfolder_simplename}.DemultiplexRunStats.Multiqc.DNA.html
-
-    rm -rf ${runfolder_simplename}_umi/Undetermined*
+    
+    mv ${runfolder_simplename}_umi/*.fastq.gz .
+    rm -rf Undetermined*
     """
 }
 
@@ -223,8 +224,8 @@ process bclConvert_RNA {
     tag "$runfolder_simplename"
     errorStrategy 'ignore'
 
-    publishDir "${fastq_dir}/${runfolder_simplename}_UMI/", mode: 'copy', pattern:"*.fastq.gz"
-    publishDir "${qc_dir}/${runfolder_simplename}_UMI/", mode: 'copy', pattern:"*.RNA.html"
+    publishDir "${fastq_dir}/${runfolder_simplename}_umi/", mode: 'copy', pattern:"*.fastq.gz"
+    publishDir "${qc_dir}/${runfolder_simplename}_umi/", mode: 'copy', pattern:"*.RNA.html"
 
     input:
     tuple val(runfolder_simplename), path(runfolder)// from runfolder_ch2
@@ -232,8 +233,8 @@ process bclConvert_RNA {
     path(runinfo) // from xml_ch
 
     output:
-    path("${runfolder_simplename}_umi/*.fastq.gz"), emit: rna_fastq// into (dna_fq_out,dna_fq_out2)
-    path("${runfolder_simplename}.DemultiplexRunStats.Multiqc.RNA.html")
+    path("*.fastq.gz"), emit: rna_fastq// into (dna_fq_out,dna_fq_out2)
+    path("*.Multiqc.RNA.html")
     script:
     """
     bcl-convert \
@@ -246,7 +247,8 @@ process bclConvert_RNA {
     -f -q ${runfolder_simplename}_umi/ \
     -n ${runfolder_simplename}.DemultiplexRunStats.Multiqc.RNA.html
 
-    rm -rf ${runfolder_simplename}_umi/Undetermined*
+    mv ${runfolder_simplename}_umi/*.fastq.gz .
+    rm -rf Undetermined*
     """
 }
 
@@ -344,8 +346,8 @@ process markDup_cram {
     errorStrategy 'ignore'
     maxForks 16
     tag "$meta.id"
-    publishDir "${aln_output_dir}/${meta.runfolder}/", mode: 'copy', pattern: "*.BWA.MD.cr*"
-        conda '/lnx01_data3/shared/programmer/miniconda3/envs/samblasterSambamba/'
+    publishDir "${aln_output_dir}/${meta.runfolder}_umi/", mode: 'copy', pattern: "*.BWA.MD.cr*"
+    conda '/lnx01_data3/shared/programmer/miniconda3/envs/samblasterSambamba/'
     input:
     tuple val(meta), path(bam)
     

--- a/modules/demulti_modules.nf
+++ b/modules/demulti_modules.nf
@@ -357,7 +357,7 @@ process markDup_cram {
     script:
     """
     samtools view -h ${bam} \
-    | samblaster | sambamba view -t 8 -S -f bam /dev/stdin | sambamba sort -t 8 --tmpdir=/data/TMP/TMP.${user}/ -o /dev/stdout /dev/stdin \
+    | samblaster | sambamba view -t 8 -S -f bam /dev/stdin | sambamba sort -t 8 --tmpdir=${tmpDIR} -o /dev/stdout /dev/stdin \
     |  samtools view \
     -T ${genome_fasta} \
     -C \

--- a/modules/demulti_modules.nf
+++ b/modules/demulti_modules.nf
@@ -158,7 +158,7 @@ process prepare_DNA_samplesheet {
     """
     cat ${samplesheet} | grep -v "RV1" > ${samplesheet_basename}.DNA_SAMPLES.csv
 
-    sed 's/Settings]/&\nOverrideCycles,${umiConvertDNA}\nNoLaneSplitting,true\nTrimUMI,0\nCreateFastqIndexForReads,1/' ${samplesheet_basename}.DNA_SAMPLES.csv > ${samplesheet_basename}.DNA_SAMPLES.UMI.csv
+    sed 's/Settings]/&/\nOverrideCycles,${umiConvertDNA}\\nNoLaneSplitting,true\nTrimUMI,0\nCreateFastqIndexForReads,1/' ${samplesheet_basename}.DNA_SAMPLES.csv > ${samplesheet_basename}.DNA_SAMPLES.UMI.csv
     """
 }
 /*

--- a/modules/demulti_modules.nf
+++ b/modules/demulti_modules.nf
@@ -140,12 +140,29 @@ process prepare_DNA_samplesheet {
     output:
     path("*.DNA_SAMPLES.csv"), emit: std
     path("*.UMI.csv"), emit: umi
+    script:
+    """
+    cat ${samplesheet} | grep -v "RV1" > ${samplesheet_basename}.DNA_SAMPLES.csv
+
+    sed 's/Settings]/&\nOverrideCycles,${umiConvertDNA}\nNoLaneSplitting,true\nTrimUMI,0\nCreateFastqIndexForReads,1/' ${samplesheet_basename}.DNA_SAMPLES.csv > !{samplesheet_basename}.DNA_SAMPLES.UMI.csv
+    """
+}
+/*
+process prepare_DNA_samplesheet {
+
+    input:
+    tuple val(samplesheet_basename), path(samplesheet)// from original_samplesheet1
+
+    output:
+    path("*.DNA_SAMPLES.csv"), emit: std
+    path("*.UMI.csv"), emit: umi
     shell:
     '''
     cat !{samplesheet} | grep -v "RV1" > !{samplesheet_basename}.DNA_SAMPLES.csv
     sed 's/Settings]/&\nOverrideCycles,!{umiConvertDNA}\nNoLaneSplitting,true\nTrimUMI,0\nCreateFastqIndexForReads,1/' !{samplesheet_basename}.DNA_SAMPLES.csv > !{samplesheet_basename}.DNA_SAMPLES.UMI.csv
     '''
 }
+*/
 
 process bclConvert_DNA {
     tag "$runfolder_simplename"
@@ -167,7 +184,6 @@ process bclConvert_DNA {
     bcl-convert \
     --sample-sheet ${dnaSS} \
     --bcl-input-directory ${runfolder} \
-    --use-bases-mask ${dnaMask} \
     -o .
 
     singularity run -B ${s_bind} ${simgpath}/multiqc.sif \

--- a/modules/demulti_modules.nf
+++ b/modules/demulti_modules.nf
@@ -89,7 +89,7 @@ switch (params.genome) {
 }
 
 dataStorage="/lnx01_data3/storage/"
-
+multiqc_config="/data/shared/programmer/configfiles/multiqc_config_tumorBoard.yaml"
 
 if (!params.useBasesMask && !params.RNA) {
   dnaMask="Y*,I8nnnnnnnnn,I8,Y*"

--- a/modules/demulti_modules.nf
+++ b/modules/demulti_modules.nf
@@ -104,6 +104,19 @@ if (params.useBasesMask) {
   params.DNA=true
 }
 
+if (params.RNA) {
+    umiConvertDNA="Y151;I8N2U9;I8N2;Y151"
+    umiConvertRNA="Y151;I10U9;I10;Y151"
+}
+
+if (!params.RNA) {
+    umiConvertDNA="Y151;I8U9;I8;Y151"
+
+}
+
+
+
+
 
 if (params.localStorage) {
 aln_output_dir="${params.outdir}/"
@@ -141,6 +154,7 @@ process prepare_DNA_samplesheet {
     path("*.DNA_SAMPLES.csv"), emit: std
     path("*.UMI.csv"), emit: umi
     script:
+
     """
     cat ${samplesheet} | grep -v "RV1" > ${samplesheet_basename}.DNA_SAMPLES.csv
 

--- a/modules/demulti_modules.nf
+++ b/modules/demulti_modules.nf
@@ -143,7 +143,7 @@ process prepare_DNA_samplesheet {
     shell:
     '''
     cat !{samplesheet} | grep -v "RV1" > !{samplesheet_basename}.DNA_SAMPLES.csv
-    sed 's/Settings]/&\nOverrideCycles,${umiConvertDNA}\nNoLaneSplitting,true\nTrimUMI,0\nCreateFastqIndexForReads,1/' !{samplesheet_basename}.DNA_SAMPLES.csv > !{samplesheet_basename}.DNA_SAMPLES.UMI.csv
+    sed 's/Settings]/&\nOverrideCycles,!{umiConvertDNA}\nNoLaneSplitting,true\nTrimUMI,0\nCreateFastqIndexForReads,1/' !{samplesheet_basename}.DNA_SAMPLES.csv > !{samplesheet_basename}.DNA_SAMPLES.UMI.csv
     '''
 }
 

--- a/modules/demulti_modules.nf
+++ b/modules/demulti_modules.nf
@@ -192,7 +192,7 @@ process bclConvert_DNA {
     tag "$runfolder_simplename"
     errorStrategy 'ignore'
 
-    publishDir "${fastq_dir}/${runfolder_simplename}_UMI/", mode: 'copy', pattern:"${runfolder_simplename}_umi/*.fastq.gz"
+    publishDir "${fastq_dir}/", mode: 'copy', pattern:"${runfolder_simplename}_umi/*.fastq.gz"
     publishDir "${qc_dir}/${runfolder_simplename}_UMI/", mode: 'copy', pattern:"*.DNA.html"
 
     input:

--- a/modules/demulti_modules.nf
+++ b/modules/demulti_modules.nf
@@ -134,8 +134,6 @@ if (!params.DNA) {
 }
 
 
-
-
 if (params.localStorage) {
 aln_output_dir="${params.outdir}/"
 fastq_dir="${params.outdir}/"
@@ -252,7 +250,8 @@ process bclConvert_RNA {
     """
 }
 
-///////////////////////////////// PREPROCESS MODULES //////////////////////// 
+
+///////////////////////////////// PREPROCESS MODULES - STANDARD //////////////////////// 
 
 
 process fastq_to_ubam {
@@ -368,7 +367,8 @@ process markDup_cram {
 }
 
 
-// UMI based analysis
+///////////////////////////////// PREPROCESS MODULES - UMI samples //////////////////////// 
+
 process fastq_to_ubam_umi {
     errorStrategy 'ignore'
     tag "$sampleID"

--- a/modules/demulti_modules.nf
+++ b/modules/demulti_modules.nf
@@ -346,7 +346,7 @@ process markDup_cram {
     errorStrategy 'ignore'
     maxForks 16
     tag "$meta.id"
-    publishDir "${aln_output_dir}/${meta.runfolder}_umi/", mode: 'copy', pattern: "*.BWA.MD.cr*"
+    publishDir "${aln_output_dir}/${meta.runfolder}_umi/", mode: 'copy', pattern: "*.cra*"
     conda '/lnx01_data3/shared/programmer/miniconda3/envs/samblasterSambamba/'
     input:
     tuple val(meta), path(bam)

--- a/modules/demulti_modules.nf
+++ b/modules/demulti_modules.nf
@@ -345,7 +345,7 @@ process markDup_cram {
     maxForks 16
     tag "$meta.id"
     publishDir "${aln_output_dir}/${meta.runfolder}/", mode: 'copy', pattern: "*.BWA.MD.cr*"
-    
+        conda '/lnx01_data3/shared/programmer/miniconda3/envs/samblasterSambamba/'
     input:
     tuple val(meta), path(bam)
     

--- a/modules/demulti_modules.nf
+++ b/modules/demulti_modules.nf
@@ -158,7 +158,7 @@ process prepare_DNA_samplesheet {
     """
     cat ${samplesheet} | grep -v "RV1" > ${samplesheet_basename}.DNA_SAMPLES.csv
 
-    sed 's/Settings]/&/\nOverrideCycles,${umiConvertDNA}\\nNoLaneSplitting,true\nTrimUMI,0\nCreateFastqIndexForReads,1/' ${samplesheet_basename}.DNA_SAMPLES.csv > ${samplesheet_basename}.DNA_SAMPLES.UMI.csv
+    sed 's/Settings]/&\\nOverrideCycles,${umiConvertDNA}\\nNoLaneSplitting,true\\nTrimUMI,0\\nCreateFastqIndexForReads,1/' ${samplesheet_basename}.DNA_SAMPLES.csv > ${samplesheet_basename}.DNA_SAMPLES.UMI.csv
     """
 }
 /*

--- a/modules/demulti_modules.nf
+++ b/modules/demulti_modules.nf
@@ -232,7 +232,7 @@ process prepare_RNA_samplesheet {
 process bcl2fastq_RNA {
     tag "$runfolder_simplename"
     errorStrategy 'ignore'
-    publishDir "${fastq_dir}/${runfolder_simplename}/", mode: 'copy'
+    publishDir "${fastq_dir}/${runfolder_simplename}_umi/", mode: 'copy'
 
     input:
     tuple val(runfolder_simplename), path(runfolder)// from runfolder_ch3

--- a/modules/demulti_modules.nf
+++ b/modules/demulti_modules.nf
@@ -189,7 +189,7 @@ process bclConvert_DNA {
     tag "$runfolder_simplename"
     errorStrategy 'ignore'
 
-    publishDir "${fastq_dir}/${runfolder_simplename}_UMI/", mode: 'copy', pattern:"*.fastq.gz"
+    publishDir "${fastq_dir}/${runfolder_simplename}_UMI/", mode: 'copy', pattern:"${runfolder_simplename}_umi/*.fastq.gz"
     publishDir "${qc_dir}/${runfolder_simplename}_UMI/", mode: 'copy', pattern:"*.DNA.html"
 
     input:


### PR DESCRIPTION
Changed demultiplexing design to include UMI sequences in fastq header (for optional use in downstream UMI based applications).

- Changed demultiplexing tool from bcl2fastq to bclconvert.
- Added MultiQC demultiplexing runstatistics for each run.
